### PR TITLE
add total_violations to experiment.table

### DIFF
--- a/jijbench/containers/containers.py
+++ b/jijbench/containers/containers.py
@@ -357,6 +357,9 @@ class Table(Container[pd.DataFrame]):
         if constraint_violations:
             for k, v in constraint_violations.items():
                 data[f"{k}_violations"] = np.array(v)
+            data["total_violations"] = np.sum(
+                list(constraint_violations.values()), axis=0
+            )
 
         data["num_samples"] = sum(sampleset.record.num_occurrences)
         data["num_feasible"] = sum(sampleset.feasible().record.num_occurrences)

--- a/jijbench/exceptions/__init__.py
+++ b/jijbench/exceptions/__init__.py
@@ -3,7 +3,6 @@ from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
 import jijbench.exceptions.exceptions as exceptions
-from jijbench.exceptions.exceptions import (ConcurrentFailedError,
-                                            SolverFailedError)
+from jijbench.exceptions.exceptions import ConcurrentFailedError, SolverFailedError
 
 __all__ = ["exceptions", "ConcurrentFailedError", "SolverFailedError"]

--- a/jijbench/functions/__init__.py
+++ b/jijbench/functions/__init__.py
@@ -4,8 +4,7 @@ __path__ = extend_path(__path__, __name__)
 
 
 from jijbench.functions.concat import Concat
-from jijbench.functions.factory import (ArtifactFactory, RecordFactory,
-                                        TableFactory)
+from jijbench.functions.factory import ArtifactFactory, RecordFactory, TableFactory
 from jijbench.functions.math import Max, Mean, Min, Std
 
 __all__ = [

--- a/jijbench/visualization/metrics/parallelplot/parallelplot.py
+++ b/jijbench/visualization/metrics/parallelplot/parallelplot.py
@@ -291,18 +291,6 @@ class MetricsParallelPlot:
                     column_name=violation_column_name,
                 )
 
-        # Extract series about violations from data_to_create_df_parallelplot (key starts with 'samplemean_' and ends with '_violations') and calculates samplemean_total_violations by taking sum.
-        start, end = re.compile(r"^samplemean_"), re.compile(r"_violations$")
-        violation_series = [
-            series
-            for name, series in data_to_create_df_parallelplot.items()
-            if start.search(name) and end.search(name)
-        ]
-        if violation_series:
-            data_to_create_df_parallelplot["samplemean_total_violations"] = sum(
-                violation_series
-            )
-
         self.df_parallelplot = df_parallelplot = pd.DataFrame(
             data_to_create_df_parallelplot
         )

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -141,6 +141,7 @@ def test_experiment_with_solver_outputing_jm_sampleset(
         "objective",
         "onehot1_violations",
         "onehot2_violations",
+        "total_violations",
         "num_samples",
         "num_feasible",
         "execution_time",


### PR DESCRIPTION
## Changed
* solverがjm.SampleSetをReturnする時、constraint_violationsの合計値をtotal_violationsとして返却するようにしました。

## Misc
* parallelplotの変更についての補足ですが、元々parallelplotは自身でtotal_violationsを計算してましたが、今回の変更で不要になったため該当部分を削除しました。